### PR TITLE
Response 고치기 및 MethodNotValidArgumentException Handle

### DIFF
--- a/src/main/java/animores/serverapi/common/Response.java
+++ b/src/main/java/animores/serverapi/common/Response.java
@@ -39,6 +39,6 @@ public class Response<T> {
         return new Response<>(false, message);
     }
 
-    private record ErrorResponse(String code, String message) {
+    private record ErrorResponse(@JsonInclude(Include.NON_NULL) String code, String message) {
     }
 }

--- a/src/main/java/animores/serverapi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/animores/serverapi/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package animores.serverapi.common.exception;
 import animores.serverapi.common.Response;
 import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -10,10 +11,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(ValidationException.class)
-    public Response<Void> handleValidationException(ValidationException e) {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public Response<Void> handleValidationException(MethodArgumentNotValidException e) {
         log.error("validation exception", e);
-        return Response.error(e.getMessage());
+        return Response.error(e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
     }
 
     @ExceptionHandler(CustomException.class)


### PR DESCRIPTION
### Changes
-----
1.  success response 일 때, error null 표시되는 걸 고침
2. ValidException 이 아니라 MethodArgumentNotValidException 을 handle 하도록 수정