### PR TITLE
일지 수정 api 구현 완료

### DIFF
--- a/src/main/java/animores/serverapi/common/exception/ExceptionCode.java
+++ b/src/main/java/animores/serverapi/common/exception/ExceptionCode.java
@@ -15,7 +15,8 @@ public enum ExceptionCode {
     UNHANDLED_EXCEPTION("error_code","알 수 없는 에러가 발생했습니다."),
 
     // 일지
-    UNSUPPORTED_TYPE("", "지원하지 않는 파일 형식입니다.");
+    UNSUPPORTED_TYPE("", "지원하지 않는 파일 형식입니다."),
+    NOT_FOUND_DIARY_MEDIA("", "해당 미디어를 찾을 수 없습니다.");
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/animores/serverapi/diary/controller/DiaryController.java
+++ b/src/main/java/animores/serverapi/diary/controller/DiaryController.java
@@ -4,6 +4,7 @@ import animores.serverapi.common.Response;
 import animores.serverapi.diary.dto.AddDiaryRequest;
 import animores.serverapi.diary.dto.EditDiaryContentRequest;
 import animores.serverapi.diary.dto.EditDiaryMediaRequest;
+import animores.serverapi.diary.dto.EditDiaryRequest;
 import animores.serverapi.diary.dto.GetAllDiaryResponse;
 import animores.serverapi.diary.dto.GetCalendarDiaryResponse;
 import animores.serverapi.diary.service.DiaryService;

--- a/src/main/java/animores/serverapi/diary/controller/DiaryController.java
+++ b/src/main/java/animores/serverapi/diary/controller/DiaryController.java
@@ -62,6 +62,22 @@ public class DiaryController {
         return Response.success(null);
     }
 
+    // 일지 내용+미디어 수정
+//    @PatchMapping("/{diaryId}")
+//    public Response<Void> editDiaryContent(@PathVariable Long diaryId,
+//        @RequestBody EditDiaryRequest request) {
+//        diaryService.editDiaryContent(diaryId, request);
+//        return Response.success(null);
+//    }
+
+    // 일지 미디어 추가
+    @PostMapping("/{diaryId}/diary-media")
+    public Response<Void> addDiaryMedia(@PathVariable Long diaryId,
+        @RequestPart(name = "files") List<MultipartFile> files) throws IOException {
+        diaryService.addDiaryMedia(diaryId, files);
+        return Response.success(null);
+    }
+
     // 일지 미디어 수정 (삭제+추가)
     @PutMapping("/{diaryId}/diary-media")
     public Response<Void> editDiaryMedia(@PathVariable Long diaryId,
@@ -71,25 +87,13 @@ public class DiaryController {
         return Response.success(null);
     }
 
-//    // 일지 미디어 삭제
-//    @DeleteMapping("/{diaryId}/diary-media")
-//    public void removeDiaryMedia(@PathVariable Long diaryId, @RequestBody EditDiaryMediaRequest request) {
-//
-//    }
-//
-//    // 일지 미디어 추가
-//    @PutMapping("/{diaryId}/diary-media")
-//    public void addDiaryMedia(@PathVariable Long diaryId, @RequestPart(name="files") List<MultipartFile> files) {
-//
-//    }
-
-    // 일지 내용+미디어 수정
-//    @PatchMapping("/{diaryId}")
-//    public Response<Void> editDiaryContent(@PathVariable Long diaryId,
-//        @RequestBody EditDiaryRequest request) {
-//        diaryService.editDiaryContent(diaryId, request);
-//        return Response.success(null);
-//    }
+    // 일지 미디어 삭제
+    @DeleteMapping("/{diaryId}/diary-media")
+    public Response<Void> removeDiaryMedia(@PathVariable Long diaryId,
+        @RequestBody EditDiaryMediaRequest request) {
+        diaryService.removeDiaryMedia(diaryId, request);
+        return Response.success(null);
+    }
 
     @DeleteMapping("/{diaryId}")
     public Response<Void> removeDiary(@PathVariable Long diaryId) {

--- a/src/main/java/animores/serverapi/diary/controller/DiaryController.java
+++ b/src/main/java/animores/serverapi/diary/controller/DiaryController.java
@@ -2,7 +2,8 @@ package animores.serverapi.diary.controller;
 
 import animores.serverapi.common.Response;
 import animores.serverapi.diary.dto.AddDiaryRequest;
-import animores.serverapi.diary.dto.EditDiaryRequest;
+import animores.serverapi.diary.dto.EditDiaryContentRequest;
+import animores.serverapi.diary.dto.EditDiaryMediaRequest;
 import animores.serverapi.diary.dto.GetAllDiaryResponse;
 import animores.serverapi.diary.dto.GetCalendarDiaryResponse;
 import animores.serverapi.diary.service.DiaryService;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -52,13 +54,42 @@ public class DiaryController {
         return Response.success(null);
     }
 
-    // 일지 수정
+    // 일지 내용 수정
     @PatchMapping("/{diaryId}")
-    public Response<Void> editDiary(@PathVariable Long diaryId,
-        @RequestBody EditDiaryRequest request) {
-        diaryService.editDiary(diaryId, request);
+    public Response<Void> editDiaryContent(@PathVariable Long diaryId,
+        @RequestBody EditDiaryContentRequest request) {
+        diaryService.editDiaryContent(diaryId, request);
         return Response.success(null);
     }
+
+    // 일지 미디어 수정 (삭제+추가)
+    @PutMapping("/{diaryId}/diary-media")
+    public Response<Void> editDiaryMedia(@PathVariable Long diaryId,
+        @RequestPart EditDiaryMediaRequest request,
+        @RequestPart(name="files") List<MultipartFile> files) throws IOException {
+        diaryService.editDiaryMedia(diaryId, request, files);
+        return Response.success(null);
+    }
+
+//    // 일지 미디어 삭제
+//    @DeleteMapping("/{diaryId}/diary-media")
+//    public void removeDiaryMedia(@PathVariable Long diaryId, @RequestBody EditDiaryMediaRequest request) {
+//
+//    }
+//
+//    // 일지 미디어 추가
+//    @PutMapping("/{diaryId}/diary-media")
+//    public void addDiaryMedia(@PathVariable Long diaryId, @RequestPart(name="files") List<MultipartFile> files) {
+//
+//    }
+
+    // 일지 내용+미디어 수정
+//    @PatchMapping("/{diaryId}")
+//    public Response<Void> editDiaryContent(@PathVariable Long diaryId,
+//        @RequestBody EditDiaryRequest request) {
+//        diaryService.editDiaryContent(diaryId, request);
+//        return Response.success(null);
+//    }
 
     @DeleteMapping("/{diaryId}")
     public Response<Void> removeDiary(@PathVariable Long diaryId) {

--- a/src/main/java/animores/serverapi/diary/dto/EditDiaryContentRequest.java
+++ b/src/main/java/animores/serverapi/diary/dto/EditDiaryContentRequest.java
@@ -3,7 +3,7 @@ package animores.serverapi.diary.dto;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
-public record EditDiaryRequest(
+public record EditDiaryContentRequest(
     @NotNull
     @NotEmpty
     String content

--- a/src/main/java/animores/serverapi/diary/dto/EditDiaryMediaRequest.java
+++ b/src/main/java/animores/serverapi/diary/dto/EditDiaryMediaRequest.java
@@ -2,11 +2,12 @@ package animores.serverapi.diary.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
-public record EditDiaryRequest(
+public record EditDiaryMediaRequest(
     @NotNull
     @NotEmpty
-    String content
+    List<Long> mediaIds
 ) {
 
 }

--- a/src/main/java/animores/serverapi/diary/entity/Diary.java
+++ b/src/main/java/animores/serverapi/diary/entity/Diary.java
@@ -2,7 +2,6 @@ package animores.serverapi.diary.entity;
 
 import animores.serverapi.account.domain.Account;
 import animores.serverapi.common.BaseEntity;
-import animores.serverapi.diary.dto.EditDiaryRequest;
 import animores.serverapi.profile.domain.Profile;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -65,8 +64,8 @@ public class Diary extends BaseEntity {
             .build();
     }
 
-    public void update(EditDiaryRequest request) {
-        this.content = request.content();
+    public void updateContent(String content) {
+        this.content = content;
     }
 
     public void delete() {

--- a/src/main/java/animores/serverapi/diary/entity/DiaryMedia.java
+++ b/src/main/java/animores/serverapi/diary/entity/DiaryMedia.java
@@ -50,5 +50,8 @@ public class DiaryMedia extends BaseEntity {
             .build();
     }
 
+    public void updateMediaOrder(int order) {
+        this.mediaOrder = order;
+    }
 
 }

--- a/src/main/java/animores/serverapi/diary/entity/DiaryMediaType.java
+++ b/src/main/java/animores/serverapi/diary/entity/DiaryMediaType.java
@@ -1,5 +1,17 @@
 package animores.serverapi.diary.entity;
 
+import animores.serverapi.common.exception.CustomException;
+import animores.serverapi.common.exception.ExceptionCode;
+
 public enum DiaryMediaType {
-    I, V
+    I, V;
+
+    public static DiaryMediaType checkType(String type) {
+        return switch (type) {
+            case "image/png", "image/jpeg" -> I;
+            case "video/mp4" -> V;
+            default -> throw new CustomException(ExceptionCode.UNSUPPORTED_TYPE);
+        };
+    }
+
 }

--- a/src/main/java/animores/serverapi/diary/repository/DiaryMediaCustomRepository.java
+++ b/src/main/java/animores/serverapi/diary/repository/DiaryMediaCustomRepository.java
@@ -1,0 +1,11 @@
+package animores.serverapi.diary.repository;
+
+import animores.serverapi.diary.entity.DiaryMedia;
+import animores.serverapi.diary.entity.DiaryMediaType;
+import java.util.List;
+
+public interface DiaryMediaCustomRepository {
+
+    List<DiaryMedia> getAllDiaryMediaToReorder(Long diaryId, DiaryMediaType type);
+
+}

--- a/src/main/java/animores/serverapi/diary/repository/DiaryMediaRepository.java
+++ b/src/main/java/animores/serverapi/diary/repository/DiaryMediaRepository.java
@@ -1,11 +1,13 @@
 package animores.serverapi.diary.repository;
 
 import animores.serverapi.diary.entity.DiaryMedia;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DiaryMediaRepository extends JpaRepository<DiaryMedia, Long> {
 
+    List<DiaryMedia> findByIdIn(List<Long> ids);
 
 }

--- a/src/main/java/animores/serverapi/diary/repository/impl/DiaryMediaCustomRepositoryImpl.java
+++ b/src/main/java/animores/serverapi/diary/repository/impl/DiaryMediaCustomRepositoryImpl.java
@@ -1,0 +1,36 @@
+package animores.serverapi.diary.repository.impl;
+
+import static animores.serverapi.diary.entity.QDiaryMedia.diaryMedia;
+
+import animores.serverapi.diary.entity.DiaryMedia;
+import animores.serverapi.diary.entity.DiaryMediaType;
+import animores.serverapi.diary.repository.DiaryMediaCustomRepository;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.swagger.v3.oas.models.media.MediaType;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DiaryMediaCustomRepositoryImpl implements DiaryMediaCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<DiaryMedia> getAllDiaryMediaToReorder(Long diaryId, DiaryMediaType type) {
+        return jpaQueryFactory
+            .selectFrom(diaryMedia)
+            .where(diaryMedia.diary.id.eq(diaryId))
+            .orderBy(new CaseBuilder()
+                    .when(diaryMedia.type.eq(type)).then(1)
+                    .otherwise(0).desc(),
+                diaryMedia.id.asc())
+            .fetch();
+    }
+}

--- a/src/main/java/animores/serverapi/diary/service/DiaryService.java
+++ b/src/main/java/animores/serverapi/diary/service/DiaryService.java
@@ -1,6 +1,8 @@
 package animores.serverapi.diary.service;
 
 import animores.serverapi.diary.dto.AddDiaryRequest;
+import animores.serverapi.diary.dto.EditDiaryContentRequest;
+import animores.serverapi.diary.dto.EditDiaryMediaRequest;
 import animores.serverapi.diary.dto.EditDiaryRequest;
 import animores.serverapi.diary.dto.GetAllDiaryResponse;
 import animores.serverapi.diary.dto.GetCalendarDiaryResponse;
@@ -17,7 +19,10 @@ public interface DiaryService {
 
     void addDiary(AddDiaryRequest request, List<MultipartFile> files) throws IOException;
 
-    void editDiary(Long diaryId, EditDiaryRequest request);
+    void editDiaryContent(Long diaryId, EditDiaryContentRequest request);
+
+    void editDiaryMedia(Long diaryId, EditDiaryMediaRequest request, List<MultipartFile> files)
+        throws IOException;
 
     void removeDiary(Long removeDiary);
 

--- a/src/main/java/animores/serverapi/diary/service/DiaryService.java
+++ b/src/main/java/animores/serverapi/diary/service/DiaryService.java
@@ -21,8 +21,12 @@ public interface DiaryService {
 
     void editDiaryContent(Long diaryId, EditDiaryContentRequest request);
 
+    void addDiaryMedia(Long diaryId, List<MultipartFile> files) throws IOException;
+
     void editDiaryMedia(Long diaryId, EditDiaryMediaRequest request, List<MultipartFile> files)
         throws IOException;
+
+    void removeDiaryMedia(Long diaryId, EditDiaryMediaRequest request);
 
     void removeDiary(Long removeDiary);
 

--- a/src/main/java/animores/serverapi/diary/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/animores/serverapi/diary/service/impl/DiaryServiceImpl.java
@@ -116,13 +116,9 @@ public class DiaryServiceImpl implements DiaryService {
 
         uploadFileToS3(files);
 
-        List<DiaryMedia> diaryMedias = createDiaryMedias(diary, files);
-        diaryMediaRepository.saveAll(diaryMedias);
+        diaryMediaRepository.saveAll(createDiaryMedias(diary, files));
 
-        List<DiaryMedia> mediaListToReorder = diaryMediaCustomRepository.getAllDiaryMediaToReorder(
-            diary.getId(),
-            DiaryMediaType.I);
-        reorderDiaryMedia(mediaListToReorder);
+        reorderDiaryMedia(diary.getId(), DiaryMediaType.I);
     }
 
     @Override
@@ -143,9 +139,7 @@ public class DiaryServiceImpl implements DiaryService {
 
         diaryMediaRepository.saveAll(createDiaryMedias(diary, files));
 
-        List<DiaryMedia> mediaListToReorder = diaryMediaCustomRepository.getAllDiaryMediaToReorder(diary.getId(),
-            DiaryMediaType.I);
-        reorderDiaryMedia(mediaListToReorder);
+        reorderDiaryMedia(diary.getId(), DiaryMediaType.I);
     }
 
     @Override
@@ -161,10 +155,7 @@ public class DiaryServiceImpl implements DiaryService {
         removeFileFromS3(mediaListToDelete);
         diaryMediaRepository.deleteAll(mediaListToDelete);
 
-        List<DiaryMedia> mediaListToReorder = diaryMediaCustomRepository.getAllDiaryMediaToReorder(
-            diary.getId(),
-            DiaryMediaType.I);
-        reorderDiaryMedia(mediaListToReorder);
+        reorderDiaryMedia(diary.getId(), DiaryMediaType.I);
     }
 
     @Override
@@ -201,7 +192,10 @@ public class DiaryServiceImpl implements DiaryService {
             .collect(Collectors.toList());
     }
 
-    public void reorderDiaryMedia(List<DiaryMedia> mediaList) {
+    public void reorderDiaryMedia(Long diaryId, DiaryMediaType type) {
+        List<DiaryMedia> mediaList = diaryMediaCustomRepository.getAllDiaryMediaToReorder(diaryId,
+            type);
+
         for (int i = 0; i < mediaList.size(); i++) {
             mediaList.get(i).updateMediaOrder(i);
         }

--- a/src/main/java/animores/serverapi/diary/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/animores/serverapi/diary/service/impl/DiaryServiceImpl.java
@@ -1,8 +1,5 @@
 package animores.serverapi.diary.service.impl;
 
-import static animores.serverapi.diary.entity.DiaryMediaType.I;
-import static animores.serverapi.diary.entity.DiaryMediaType.V;
-
 import animores.serverapi.account.domain.Account;
 import animores.serverapi.account.repository.AccountRepository;
 import animores.serverapi.common.exception.CustomException;
@@ -33,7 +30,6 @@ import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -182,7 +178,7 @@ public class DiaryServiceImpl implements DiaryService {
             .mapToObj(i -> {
                 MultipartFile file = files.get(i);
                 return DiaryMedia.create(diary, "/" + file.getOriginalFilename(), i,
-                    checkType(file.getContentType()));
+                    DiaryMediaType.checkType(file.getContentType()));
             })
             .collect(Collectors.toList());
     }
@@ -194,14 +190,6 @@ public class DiaryServiceImpl implements DiaryService {
         for (int i = 0; i < mediaList.size(); i++) {
             mediaList.get(i).updateMediaOrder(i);
         }
-    }
-
-    public DiaryMediaType checkType(String type) {
-        return switch (type) {
-            case "image/png" -> I;
-            case "video/mp4" -> V;
-            default -> throw new IllegalArgumentException("Unsupported type: " + type);
-        };
     }
 
     private List<ObjectIdentifier> generateKeysForS3Deletion(List<DiaryMedia> mediaList) {

--- a/src/main/java/animores/serverapi/util/S3Util.java
+++ b/src/main/java/animores/serverapi/util/S3Util.java
@@ -1,0 +1,45 @@
+package animores.serverapi.util;
+
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+@RequiredArgsConstructor
+public class S3Util {
+
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public void uploadFilesToS3(List<MultipartFile> files) throws IOException {
+        for (MultipartFile file : files) {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .contentType(file.getContentType())
+                .contentLength(file.getSize())
+                .key(file.getOriginalFilename())
+                .build();
+            RequestBody requestBody = RequestBody.fromBytes(file.getBytes());
+            s3Client.putObject(putObjectRequest, requestBody);
+        }
+    }
+
+    public void removeFilesFromS3(List<ObjectIdentifier> keys) {
+        DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
+            .bucket(bucketName)
+            .delete(b -> b.objects(keys))
+            .build();
+
+        s3Client.deleteObjects(deleteObjectsRequest);
+    }
+}


### PR DESCRIPTION
- 일지의 내용만 수정하는 api
   내용 업데이트
- 일지의 미디어를 추가만 하는 api
   s3에 파일 업로드, 테이블에 데이터 추가, 순서 재정렬
- 일지의 미디어를 추가+삭제 하는 api
   s3에 업로드된 파일 삭제, 테이블 데이터 삭제, s3에 새로운 파일 업로드, 테이블에 새로운 데이터 추가, 순서 재정렬
- 일지의 미디어를 삭제하는 api
   s3에 업로드된 파일 삭제, 테이블 데이터 삭제

내용과 미디어 둘다 수정사항이 있는 경우에 대한 api를 추가하려고 했으나
구현된 위의 4개 api와 겹치는 부분이 많을것같고, if문 처리때문에 api들을 분리한 의미가 크게 없을것같아서
내용과 미디어 둘다 수정사항이 있는 경우 client에서 api를 2개 요청하는방식으로 하는건 어떨까 하는데 이 부분도 의견 부탁드림!