### PR TITLE
Prometheus & Grafana 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/gradle
 ./src/main/resources/application-prod.yaml
+prometheus.yml

--- a/Dockerfile-grafana
+++ b/Dockerfile-grafana
@@ -1,0 +1,1 @@
+FROM  grafana/grafana:latest

--- a/Dockerfile-prometheus
+++ b/Dockerfile-prometheus
@@ -1,0 +1,2 @@
+FROM  prom/prometheus:latest
+COPY ./prometheus.yml /etc/prometheus/prometheus.yml

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-aws-s3:3.0.2'
 
 
+	// Monitoring
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 jacocoTestReport {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,3 +42,9 @@ spring:
     redis:
       host: ${redis_endpoint}
       port: 6379
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"


### PR DESCRIPTION
밑에 있는 블로그 글을 보고 ECS 에 Prometheus 와 Grafana Service 를 추가를 진행을 하려고 합니다.
Prometheus 와 Grafana 는 서버를 monitoring 하고 그를 도식화하는 Library 등으로 앞으로 효과적인 모니터링을 위해 추가하려고 합니다.

https://velog.io/@roycewon/Spring-boot-%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81Prometheus-Grafana-docker