### PR TITLE
account Auth 수정 및 Swagger 설명 추가

### DIFF
--- a/src/main/java/animores/serverapi/account/controller/AccountController.java
+++ b/src/main/java/animores/serverapi/account/controller/AccountController.java
@@ -1,6 +1,7 @@
 package animores.serverapi.account.controller;
 
 
+import animores.serverapi.account.domain.Account;
 import animores.serverapi.account.request.SignInRequest;
 import animores.serverapi.account.request.SignOutRequest;
 import animores.serverapi.account.request.SignUpRequest;
@@ -9,11 +10,12 @@ import animores.serverapi.account.response.SignUpResponse;
 import animores.serverapi.account.service.AccountService;
 import animores.serverapi.account.service.EmailAuthService;
 import animores.serverapi.common.Response;
+import animores.serverapi.common.aop.UserInfo;
 import animores.serverapi.security.RefreshRequest;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
@@ -33,17 +35,15 @@ public class AccountController {
     private final AccountService accountService;
     private final EmailAuthService emailAuthService;
 
-    @PostMapping("/refresh")
-    public Response<SignInResponse> refresh(@Valid @RequestBody RefreshRequest request) {
-        return Response.success(accountService.refresh(request));
-    }
-
     @PostMapping("/sign-up")
+    @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
     public Response<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest request) {
+        emailAuthService.checkVerifiedEmail(request.email());
         return Response.success(accountService.signUp(request));
     }
 
     @PostMapping("/sign-in")
+    @Operation(summary = "로그인", description = "로그인을 진행합니다.")
     public Response<SignInResponse> signIn(@Valid @RequestBody SignInRequest request) {
         return Response.success(accountService.signIn(request));
     }
@@ -51,29 +51,45 @@ public class AccountController {
     @PostMapping("/sign-out")
     @PreAuthorize("hasAuthority('USER')")
     @SecurityRequirement(name = "Authorization")
-    public ResponseEntity<Void> signOut(@Valid @RequestBody SignOutRequest request, @AuthenticationPrincipal User user) {
-        accountService.signOut(request, user);
+    @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
+    public ResponseEntity<Void> signOut(@Valid @RequestBody SignOutRequest request,
+                                        @RequestHeader("Authorization") String token,
+                                        @AuthenticationPrincipal User user) {
+        accountService.signOut(request, token, user);
         return ResponseEntity.noContent().build();
     }
 
+    @UserInfo
+    @PostMapping("/refresh")
+    @PreAuthorize("hasAuthority('USER')")
+    @SecurityRequirement(name = "Authorization")
+    @Operation(summary = "토큰 재발급", description = "Access 토큰을 재발급합니다.")
+    public Response<SignInResponse> refresh(@Valid @RequestBody RefreshRequest request) {
+        Account account = accountService.getAccountFromContext();
+        return Response.success(accountService.refresh(request, account.getId()));
+    }
 
     @GetMapping("/check-email/{email}")
+    @Operation(summary = "이메일 중복 체크", description = "이메일 중복을 체크합니다.")
     public Response<Boolean> isDuplicatedEmail(@PathVariable @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,6}$") String email) {
         return Response.success(accountService.isDuplicatedEmail(email));
     }
 
     @GetMapping("/check-nickname/{nickname}")
+    @Operation(summary = "닉네임 중복 체크", description = "닉네임 중복을 체크합니다.")
     public Response<Boolean> isDuplicatedNickname(@PathVariable @Size(min = 2, max = 8) String nickname) {
         return Response.success(accountService.isDuplicatedNickname(nickname));
     }
 
     @PostMapping("/email-auth-create")
+    @Operation(summary = "이메일 인증코드 생성", description = "이메일 인증코드를 생성합니다.")
     public Response<Void> sendAuthEmail(@RequestParam @Email(message = "이메일 형식으로 입력해주세요.") String email) {
         emailAuthService.sendEmail(email, emailAuthService.createAuthCode(email));
         return Response.success(null);
     }
 
     @PostMapping("/email-auth-verify")
+    @Operation(summary = "이메일 인증코드 확인", description = "이메일 인증코드를 확인합니다.")
     public Response<Boolean> verifyEmail(@RequestParam @Email(message = "이메일 형식으로 입력해주세요.") String email,
                                          @RequestParam String code) {
         return Response.success(emailAuthService.verifyEmail(email, code));

--- a/src/main/java/animores/serverapi/account/request/SignInRequest.java
+++ b/src/main/java/animores/serverapi/account/request/SignInRequest.java
@@ -1,15 +1,18 @@
 package animores.serverapi.account.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "로그인 요청")
 public record SignInRequest (
 
         @Email(message = "이메일 형식이 아닙니다.")
+        @Schema(description = "이메일", example = "abc@gmail.com")
         String email,
 
         @NotEmpty(message = "비밀번호를 입력 하세요.")
+        @Schema(description = "비밀번호", example = "abc123!@#")
         String password
 
 ) {

--- a/src/main/java/animores/serverapi/account/request/SignOutRequest.java
+++ b/src/main/java/animores/serverapi/account/request/SignOutRequest.java
@@ -3,10 +3,6 @@ package animores.serverapi.account.request;
 import jakarta.validation.constraints.NotEmpty;
 
 public record SignOutRequest(
-
-        @NotEmpty(message = "accessToken을 입력 하세요.")
-        String accessToken,
-
         @NotEmpty(message = "refreshToken을 입력 하세요.")
         String refreshToken
 

--- a/src/main/java/animores/serverapi/account/request/SignOutRequest.java
+++ b/src/main/java/animores/serverapi/account/request/SignOutRequest.java
@@ -1,9 +1,12 @@
 package animores.serverapi.account.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 
+@Schema(description = "로그아웃 요청")
 public record SignOutRequest(
-        @NotEmpty(message = "refreshToken을 입력 하세요.")
+        @Schema(description = "refresh token", example = "refresh token")
+        @NotEmpty(message = "refresh token을 입력 하세요.")
         String refreshToken
 
 ) {

--- a/src/main/java/animores/serverapi/account/request/SignUpRequest.java
+++ b/src/main/java/animores/serverapi/account/request/SignUpRequest.java
@@ -1,23 +1,29 @@
 package animores.serverapi.account.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
+@Schema(description = "회원가입 요청")
 public record SignUpRequest(
 
         @Email(message = "이메일 형식이 아닙니다.")
+        @Schema(description = "이메일", example = "abc@gmail.com")
         String email,
 
         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[^a-zA-Z0-9]).{8,30}$",
                 message = "8~30자리 영대소문자, 숫자, 특수문자 조합이어야 합니다.")
+        @Schema(description = "비밀번호", example = "abc123!@#")
         String password,
 
         @NotEmpty(message = "닉네임을 입력 하세요.")
+        @Schema(description = "닉네임", example = "닉네임")
         String nickname,
 
         @NotNull(message = "광고 수신 여부를 입력 하세요.")
+        @Schema(description = "광고 수신 여부", example = "true")
         Boolean isAdPermission
 
 ) {

--- a/src/main/java/animores/serverapi/account/service/AccountService.java
+++ b/src/main/java/animores/serverapi/account/service/AccountService.java
@@ -10,32 +10,12 @@ import animores.serverapi.security.RefreshRequest;
 import org.springframework.security.core.userdetails.User;
 
 public interface AccountService {
-
-    /**
-     * accessToken 재발급
-     * @param request
-     * @return
-     */
-    SignInResponse refresh(RefreshRequest request);
-
     /**
      * 계정 생성
      * @param request
      * @return
      */
     SignUpResponse signUp(SignUpRequest request);
-
-    /**
-     * 이메일 중복 체크
-     * @param email
-     */
-    boolean isDuplicatedEmail(String email);
-
-    /**
-     * 닉네임 중복 체크
-     * @param nickname
-     */
-    boolean isDuplicatedNickname(String nickname);
 
     /**
      * 로그인
@@ -48,7 +28,26 @@ public interface AccountService {
      * 로그아웃
      * @param request
      */
-    void signOut(SignOutRequest request, User user);
+    void signOut(SignOutRequest request, String token, User user);
+
+    /**
+     * accessToken 재발급
+     * @param request
+     * @return
+     */
+    SignInResponse refresh(RefreshRequest request, Long userId);
+
+    /**
+     * 이메일 중복 체크
+     * @param email
+     */
+    boolean isDuplicatedEmail(String email);
+
+    /**
+     * 닉네임 중복 체크
+     * @param nickname
+     */
+    boolean isDuplicatedNickname(String nickname);
 
     Account getAccountFromContext();
 

--- a/src/main/java/animores/serverapi/account/service/EmailAuthService.java
+++ b/src/main/java/animores/serverapi/account/service/EmailAuthService.java
@@ -3,6 +3,6 @@ package animores.serverapi.account.service;
 public interface EmailAuthService {
     void sendEmail(String email, String code);
     boolean verifyEmail(String email, String code);
-
+    void checkVerifiedEmail(String email);
     String createAuthCode(String email);
 }

--- a/src/main/java/animores/serverapi/account/service/impl/AccountServiceImpl.java
+++ b/src/main/java/animores/serverapi/account/service/impl/AccountServiceImpl.java
@@ -44,8 +44,12 @@ public class AccountServiceImpl implements AccountService {
     @Override
     public SignInResponse signIn(SignInRequest request) {
         Account account = accountRepository.findByEmail(request.email())
-                .filter(ac -> passwordEncoder.matches(request.password(), ac.getPassword()))// 비밀번호 확인
                 .orElseThrow(() -> new CustomException(ExceptionCode.INVALID_USER));
+
+        if (!passwordEncoder.matches(request.password(), account.getPassword())) {
+            throw new CustomException(ExceptionCode.PASSWORD_MISMATCH);// 비밀번호 확인
+        }
+
 
         // at, rt 생성
         String accessToken = tokenProvider.createToken(String.format("%s:%s", account.getId(), account.getRole()));

--- a/src/main/java/animores/serverapi/account/service/impl/AccountServiceImpl.java
+++ b/src/main/java/animores/serverapi/account/service/impl/AccountServiceImpl.java
@@ -52,7 +52,7 @@ public class AccountServiceImpl implements AccountService {
 
 
         // at, rt 생성
-        String accessToken = tokenProvider.createToken(String.format("%s:%s", account.getId(), account.getRole()));
+        String accessToken = tokenProvider.createToken(account.getId(), account.getRole());
         String refreshToken = UUID.randomUUID().toString();
         RefreshToken redisRefreshToken = new RefreshToken(refreshToken, account.getId());
         refreshTokenRepository.save(redisRefreshToken);
@@ -78,7 +78,7 @@ public class AccountServiceImpl implements AccountService {
         Account account = accountRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.INVALID_USER));
 
-        String accessToken = tokenProvider.createToken(String.format("%s:%s", account.getId(), account.getRole()));
+        String accessToken = tokenProvider.createToken(account.getId(), account.getRole());
 
         return new SignInResponse(account.getId(), accessToken, LocalDateTime.now().plusHours(tokenProvider.getExpirationHours()), refreshToken.getRefreshToken());
     }

--- a/src/main/java/animores/serverapi/account/service/impl/GoogleEmailAuthServiceImpl.java
+++ b/src/main/java/animores/serverapi/account/service/impl/GoogleEmailAuthServiceImpl.java
@@ -75,4 +75,11 @@ public class GoogleEmailAuthServiceImpl implements EmailAuthService {
 
         return false;
     }
+
+    @Override
+    public void checkVerifiedEmail(String email) {
+        if (!validMailRepository.existsById(email)) {
+            throw new CustomException(ExceptionCode.NOT_VERIFIED_EMAIL);
+        }
+    }
 }

--- a/src/main/java/animores/serverapi/common/exception/ExceptionCode.java
+++ b/src/main/java/animores/serverapi/common/exception/ExceptionCode.java
@@ -10,6 +10,7 @@ public enum ExceptionCode {
     INVALID_REFRESH_TOKEN("","해당 refresh token 을 찾을 수 없습니다" ),
     INVALID_USER("","해당 유저를 찾을 수 없습니다" ),
     EXPIRED_AUTH_CODE("", "인증 코드가 만료되었습니다."),
+    NOT_VERIFIED_EMAIL("", "이메일 인증이 되지 않았습니다."),
     //   to_do 관련 에러
     ILLEGAL_PET_IDS( "error_code","잘못된 펫이 입력되었습니다."),
     NOT_FOUND_TO_DO("", "해당 To Do를 찾을 수 없습니다."),

--- a/src/main/java/animores/serverapi/common/exception/ExceptionCode.java
+++ b/src/main/java/animores/serverapi/common/exception/ExceptionCode.java
@@ -11,6 +11,7 @@ public enum ExceptionCode {
     INVALID_USER("","해당 유저를 찾을 수 없습니다" ),
     EXPIRED_AUTH_CODE("", "인증 코드가 만료되었습니다."),
     NOT_VERIFIED_EMAIL("", "이메일 인증이 되지 않았습니다."),
+    PASSWORD_MISMATCH("", "비밀번호가 일치하지 않습니다."),
     //   to_do 관련 에러
     ILLEGAL_PET_IDS( "error_code","잘못된 펫이 입력되었습니다."),
     NOT_FOUND_TO_DO("", "해당 To Do를 찾을 수 없습니다."),

--- a/src/main/java/animores/serverapi/security/RefreshRequest.java
+++ b/src/main/java/animores/serverapi/security/RefreshRequest.java
@@ -2,8 +2,6 @@ package animores.serverapi.security;
 
 public record RefreshRequest(
 
-        Long userId,
-
         String refreshToken
 
 ) {

--- a/src/main/java/animores/serverapi/security/RefreshRequest.java
+++ b/src/main/java/animores/serverapi/security/RefreshRequest.java
@@ -1,7 +1,12 @@
 package animores.serverapi.security;
 
-public record RefreshRequest(
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 
+@Schema(description = "토큰 재발급 요청")
+public record RefreshRequest(
+        @NotEmpty(message = "refresh token을 입력 하세요.")
+        @Schema(description = "refresh token", example = "refresh token")
         String refreshToken
 
 ) {

--- a/src/main/java/animores/serverapi/security/TokenProvider.java
+++ b/src/main/java/animores/serverapi/security/TokenProvider.java
@@ -1,5 +1,6 @@
 package animores.serverapi.security;
 
+import animores.serverapi.account.type.Role;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.Getter;
@@ -28,14 +29,16 @@ public class TokenProvider {
 
     /**
      * 토큰 생성
-     * @param userSpecification
+     * @param accountId
+     * @param role
      * @return
      */
-    public String createToken(String userSpecification) {
+    public String createToken(Long accountId, Role role) {
+
 
         return Jwts.builder()
                 .signWith(new SecretKeySpec(secretKey.getBytes(), SignatureAlgorithm.HS512.getJcaName())) // HS512 알고리즘을 사용하여 secretKey를 이용해 서명
-                .setSubject(userSpecification) // JWT 토큰 제목
+                .setSubject(String.format("%s:%s", accountId, role)) // JWT 토큰 제목
                 .setIssuer(issuer) // JWT 토큰 발급자
                 .setIssuedAt(Timestamp.valueOf(LocalDateTime.now())) // JWT 토큰 발급 시간
                 .setExpiration(new Date(System.currentTimeMillis() + (long) expirationHours * 3600 * 1000)) // JWT 토큰 만료 시간

--- a/src/test/java/animores/serverapi/account/service/impl/AccountServiceImplTest.java
+++ b/src/test/java/animores/serverapi/account/service/impl/AccountServiceImplTest.java
@@ -2,9 +2,14 @@ package animores.serverapi.account.service.impl;
 
 import animores.serverapi.account.domain.Account;
 import animores.serverapi.account.repository.AccountRepository;
-import animores.serverapi.security.BlacklistTokenRepository;
-import animores.serverapi.security.RefreshTokenRepository;
-import animores.serverapi.security.TokenProvider;
+import animores.serverapi.account.request.SignInRequest;
+import animores.serverapi.account.request.SignOutRequest;
+import animores.serverapi.account.request.SignUpRequest;
+import animores.serverapi.account.response.SignInResponse;
+import animores.serverapi.account.response.SignUpResponse;
+import animores.serverapi.common.exception.CustomException;
+import animores.serverapi.common.exception.ExceptionCode;
+import animores.serverapi.security.*;
 import animores.serverapi.util.RequestConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,14 +17,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
+import java.util.ArrayList;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AccountServiceImplTest {
@@ -35,6 +44,133 @@ class AccountServiceImplTest {
     private BlacklistTokenRepository blacklistTokenRepository;
     @InjectMocks
     private AccountServiceImpl accountService;
+
+    private static final String EMAIL = "test@test.com";
+    private static final String PASSWORD = "password";
+    private static final Long ACCOUNT_ID = 1L;
+    private static final String REFRESH_TOKEN = "refreshToken";
+
+    @Test
+    void signUpSuccessfully() {
+        SignUpRequest request = new SignUpRequest(EMAIL, PASSWORD, "nickname",false);
+        when(accountRepository.save(any(Account.class))).thenReturn(new Account());
+        SignUpResponse response = accountService.signUp(request);
+
+        assertNotNull(response);
+        verify(accountRepository, times(1)).save(any(Account.class));
+    }
+
+    @Test
+    void signInSuccessfully() {
+        SignInRequest request = new SignInRequest(EMAIL, PASSWORD);
+        Account account = new TestAccount(ACCOUNT_ID, PASSWORD);
+
+        when(accountRepository.findByEmail(anyString())).thenReturn(Optional.of(account));
+        when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+        when(tokenProvider.createToken(anyString())).thenReturn("token");
+        when(tokenProvider.getExpirationHours()).thenReturn(1);
+
+        SignInResponse response = accountService.signIn(request);
+
+        assertNotNull(response);
+        assertEquals(1L, response.userId());
+        verify(accountRepository, times(1)).findByEmail(anyString());
+        verify(passwordEncoder, times(1)).matches(anyString(), anyString());
+    }
+
+    @Test
+    void signInWithInvalidCredentials() {
+        SignInRequest request = new SignInRequest(EMAIL, PASSWORD);
+        Account account = new TestAccount(ACCOUNT_ID, "NOT_MATCHED_PASSWORD");
+
+        when(accountRepository.findByEmail(anyString())).thenReturn(Optional.of(account));
+        when(passwordEncoder.matches(PASSWORD, "NOT_MATCHED_PASSWORD")).thenReturn(false);
+
+        try {
+            accountService.signIn(request);
+            throw new AssertionError("테스트 실패");
+        } catch (Exception e) {
+            assertTrue(e instanceof CustomException);
+            assertEquals(ExceptionCode.PASSWORD_MISMATCH.name(), ((CustomException) e).getCode().name());
+        }
+    }
+
+
+    @Test
+    void signInWithPasswordMismatch() {
+        SignInRequest request = new SignInRequest(EMAIL, PASSWORD);
+        when(accountRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+
+        try {
+            accountService.signIn(request);
+            throw new AssertionError("테스트 실패");
+        } catch (Exception e) {
+            assertTrue(e instanceof CustomException);
+            assertEquals(ExceptionCode.INVALID_USER.name(), ((CustomException) e).getCode().name());
+        }
+    }
+
+    @Test
+    void signOutSuccessfully() {
+        SignOutRequest request = new SignOutRequest(REFRESH_TOKEN);
+        User user = new User("1", "password", new ArrayList<>());
+
+        given(blacklistTokenRepository.save(any(BlackListToken.class)))
+                .willReturn(new BlackListToken("accessToken", 1L));
+        doNothing().when(refreshTokenRepository).deleteById(anyString());
+
+        assertDoesNotThrow(() -> accountService.signOut(request, "accessToken", user));
+    }
+
+    @Test
+    void refreshSuccessfully() {
+        RefreshRequest request = new RefreshRequest(REFRESH_TOKEN);
+
+        when(refreshTokenRepository.findById(anyString())).thenReturn(Optional.of(new RefreshToken(REFRESH_TOKEN, ACCOUNT_ID)));
+        when(accountRepository.findById(anyLong())).thenReturn(Optional.of(new Account()));
+        when(tokenProvider.createToken(anyString())).thenReturn("token");
+        when(tokenProvider.getExpirationHours()).thenReturn(1);
+
+        SignInResponse response = accountService.refresh(request, 1L);
+
+        assertNotNull(response);
+        verify(refreshTokenRepository, times(1)).findById(anyString());
+        verify(accountRepository, times(1)).findById(anyLong());
+    }
+
+    @Test
+    void refreshWithInvalidToken() {
+        RefreshRequest request = new RefreshRequest(REFRESH_TOKEN);
+        when(refreshTokenRepository.findById(anyString())).thenReturn(Optional.empty());
+        try {
+            accountService.refresh(request, 1L);
+            throw new AssertionError("테스트 실패");
+        } catch (Exception e) {
+            assertTrue(e instanceof CustomException);
+            assertEquals(ExceptionCode.INVALID_REFRESH_TOKEN.name(), ((CustomException) e).getCode().name());
+        }
+    }
+
+    @Test
+    void isDuplicatedEmail() {
+        when(accountRepository.existsByEmail(anyString())).thenReturn(true);
+
+        boolean isDuplicated = accountService.isDuplicatedEmail("test@test.com");
+
+        assertTrue(isDuplicated);
+        verify(accountRepository, times(1)).existsByEmail(anyString());
+    }
+
+    @Test
+    void isDuplicatedNickname() {
+        when(accountRepository.existsByNickname(anyString())).thenReturn(true);
+
+        boolean isDuplicated = accountService.isDuplicatedNickname("nickname");
+
+        assertTrue(isDuplicated);
+        verify(accountRepository, times(1)).existsByNickname(anyString());
+    }
+
 
     @Test
     void getAccountFromContext() {
@@ -57,6 +193,10 @@ class AccountServiceImplTest {
         class TestAccount extends Account {
             public TestAccount(Long id) {
                 super(id, null, null, null, null, false);
+            }
+
+            public TestAccount(Long id, String password) {
+                super(id, null, null, password, null, false);
             }
         }
     }

--- a/src/test/java/animores/serverapi/account/service/impl/AccountServiceImplTest.java
+++ b/src/test/java/animores/serverapi/account/service/impl/AccountServiceImplTest.java
@@ -67,7 +67,7 @@ class AccountServiceImplTest {
 
         when(accountRepository.findByEmail(anyString())).thenReturn(Optional.of(account));
         when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
-        when(tokenProvider.createToken(anyString())).thenReturn("token");
+        when(tokenProvider.createToken(any(), any())).thenReturn("token");
         when(tokenProvider.getExpirationHours()).thenReturn(1);
 
         SignInResponse response = accountService.signIn(request);
@@ -128,7 +128,7 @@ class AccountServiceImplTest {
 
         when(refreshTokenRepository.findById(anyString())).thenReturn(Optional.of(new RefreshToken(REFRESH_TOKEN, ACCOUNT_ID)));
         when(accountRepository.findById(anyLong())).thenReturn(Optional.of(new Account()));
-        when(tokenProvider.createToken(anyString())).thenReturn("token");
+        when(tokenProvider.createToken(any(), any())).thenReturn("token");
         when(tokenProvider.getExpirationHours()).thenReturn(1);
 
         SignInResponse response = accountService.refresh(request, 1L);


### PR DESCRIPTION
다음과 같은 변경점을 적용했습니다.

1. Swagger 에 account auth 관련 api 추가
2. 회원 가입할 때, 인증을 진행한 이메일인지 체크하는 로직 추가
3. 로그아웃과 token refresh 시에 불필요한 입력 제거
4. account service test 추가 