### PR TITLE
fix: 펫 조회 응답값에 펫 종류 추가 (#107)

### DIFF
--- a/src/main/java/animores/serverapi/pet/dto/response/GetPetDetailResponse.java
+++ b/src/main/java/animores/serverapi/pet/dto/response/GetPetDetailResponse.java
@@ -8,6 +8,7 @@ public record GetPetDetailResponse(
     String name,
     String imageUrl,
     BreedResponse breed,
+    SpeciesResponse species,
     LocalDate birthday,
     int gender,
     Float weight) {
@@ -18,6 +19,7 @@ public record GetPetDetailResponse(
             pet.getName(),
             pet.getImage().getUrl(),
             BreedResponse.fromEntity(pet.getBreed()),
+            SpeciesResponse.fromEntity(pet.getBreed().getSpecies()),
             pet.getBirthday(),
             pet.getGender(),
             pet.getWeight());

--- a/src/main/java/animores/serverapi/pet/service/impl/PetServiceImpl.java
+++ b/src/main/java/animores/serverapi/pet/service/impl/PetServiceImpl.java
@@ -21,6 +21,7 @@ import animores.serverapi.pet.repository.PetImageRepository;
 import animores.serverapi.pet.repository.PetRepository;
 import animores.serverapi.pet.repository.SpeciesRepository;
 import animores.serverapi.pet.service.PetService;
+import animores.serverapi.to_do.repository.PetToDoRelationshipRepository;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,6 +37,7 @@ public class PetServiceImpl implements PetService {
     private final BreedRepository breedRepository;
     private final PetRepository petRepository;
     private final PetImageRepository petImageRepository;
+    private final PetToDoRelationshipRepository petToDoRelationshipRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -129,6 +131,7 @@ public class PetServiceImpl implements PetService {
     @Transactional
     @Override
     public void deletePet(Long petId) {
+        petToDoRelationshipRepository.deleteByPet_Id(petId);
         petRepository.deleteById(petId);
     }
 }

--- a/src/main/java/animores/serverapi/to_do/repository/PetToDoRelationshipRepository.java
+++ b/src/main/java/animores/serverapi/to_do/repository/PetToDoRelationshipRepository.java
@@ -11,4 +11,6 @@ public interface PetToDoRelationshipRepository extends JpaRepository<PetToDoRela
     List<PetToDoRelationship> findAllByPet_IdIn(List<Long> petIds);
 
     void deleteAllByToDo_IdAndPet_IdIn(Long toDoId, List<Long> petIdsToDelete);
+
+    void deleteByPet_Id(Long petId);
 }

--- a/src/test/java/animores/serverapi/pet/service/impl/PetServiceImplTest.java
+++ b/src/test/java/animores/serverapi/pet/service/impl/PetServiceImplTest.java
@@ -4,10 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import animores.serverapi.account.entity.Account;
 import animores.serverapi.common.exception.CustomException;
@@ -31,6 +28,8 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import animores.serverapi.to_do.repository.PetToDoRelationshipRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -54,6 +53,9 @@ class PetServiceImplTest {
 
     @Mock
     private PetImageRepository petImageRepository;
+
+    @Mock
+    private PetToDoRelationshipRepository petToDoRelationshipRepository;
 
     private static final Long PET_ID = 1L;
     private static final Long BREED_ID = 2L;
@@ -191,6 +193,7 @@ class PetServiceImplTest {
 
     @Test
     void deletePetDeletesPet() {
+        doNothing().when(petToDoRelationshipRepository).deleteByPet_Id(PET_ID);
         petService.deletePet(PET_ID);
         verify(petRepository, times(1)).deleteById(PET_ID);
     }
@@ -205,7 +208,9 @@ class PetServiceImplTest {
     private static class TestBreed extends Breed {
 
         public TestBreed(Long id, String name) {
-            super(id, null, name);
+            super(id, Species.builder()
+                            .id(1L)
+                    .name("dfd").build(), name);
         }
     }
 


### PR DESCRIPTION
펫 조회 응답값에 펫 종류가 필요하다는 클라이언트 요청에 따라 API response 수정하였음
생성, 수정의 경우는 보류